### PR TITLE
only require `Deserialize<'de>` to avoid breakage in future Rust versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ impl FlatField {
             Span::call_site(),
         );
         let deserialize_bound = LitStr::new(
-            &format!("{}: ::serde::de::DeserializeOwned", &ty_tokens),
+            &format!("{}: ::serde::de::Deserialize<'de>", &ty_tokens),
             Span::call_site(),
         );
 


### PR DESCRIPTION
The derive currently adds `DeserializeOwned` bounds to the impl of `Deserialize<'de>`.

This means that using such a `Deserialize<'de>` impl inside of another derived `Deserialize<'de>` impl ends up requiring `DeserializeOwned` for the field, even though that impl only has a `Deserialize<'de>` where bound. An MVCE would be something like the following:
```rust
// Deriving the trait for `NeedsOwned`:
struct NeedsOwned(bool);
impl<'de> Deserialize<'de> for NeedsOwned
where
    bool: DeserializeOwned,
{
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
        D: Deserializer<'de>,
    {
        Ok(NeedsOwned(<bool as Deserialize>::deserialize(deserializer)?))
    }
}

pub fn deserialize<'de, D>(deserializer: D) -> Result<bool, D::Error>
where
    bool: Deserialize<'de>,
    D: Deserializer<'de>,
{
    // requires `bool: DeserializeOwned` which requires `for<'de> bool: Deserialize<'de>`
    match <NeedsOwned as ::serde::Deserialize>::deserialize(deserializer) {
        Ok(value) => Ok(value.0),
        Err(e) => Err(e),
    }
}
```
This is not the exact output of the derive but close enough. We previously ended up eagerly discarding the `bool: Deserialize<'de>` where-bound when proving `for<'de> bool: Deserialize<'de>` as using it results in a higher ranked region error. This caused us to use the actual impl instead. We will stop doing so once https://github.com/rust-lang/rust/pull/119820 lands, causing this to result in an error instead.

Please ask for clarification if you would like further information. I apologize for the inconvenience. I ran `cargo test` to check that this still works.